### PR TITLE
Changed the require to align with new {N} standard

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@
 /* global android, UIKeyboardDidShowNotification, UIKeyboardDidHideNotification */
 
 
-var frame = require('ui/frame');
+var frame = require('tns-core-modules/ui/frame').Frame;
 
 function trackAndroidKeyboard() {
     if (!frame.topmost()) { setTimeout(trackAndroidKeyboard, 100); return; }


### PR DESCRIPTION
This file earlier used the require
`11 | var frame = require('ui/frame')`
which has been deprecated, atleast in the latest version of {N} (6.3.2) as of writing (12 Apr, 2020) which causes an error message to be shown on running the app on the console:
`JS: topmost() is deprecated. Use Frame.topmost() instead.`
which I fixed by changing the require to<sup>1</sup>
`11 | var frame = require('tns-core-modules/ui/frame').Frame;`
to align more with how the new module works.
<hr/>
<sup>1</sup> <a href="https://docs.nativescript.org/ui/components/frame#frame-reference">Frame Reference, Frame - NativeScript Docs</a>